### PR TITLE
Animate in the Seed packs

### DIFF
--- a/src/js/packs/index.js
+++ b/src/js/packs/index.js
@@ -56,15 +56,15 @@ app.prototype.parse = function(response) {
 
 app.prototype.render = function(response) {
   var self = this;
-  var _html = '';
 
-  _.forEach(response, function(repo) {
+  _.forEach(response, function(repo, index) {
     var template = _.template(self.template)(repo);
-    _html += template;
-  });
 
-  // Render into the DOM!
-  this.$el.html(_html);
+    // Animate each repo into the DOM after three frames!
+    setTimeout(function() {
+      self.$el.append(template);
+    }, index * 50);
+  });
 
   return this;
 };


### PR DESCRIPTION
Instead of loading all the packs at once, render them in with three frames of delay between each one. Looks :star:_fancy_:star::

![packs-animation](https://cloud.githubusercontent.com/assets/68917/17041463/10f831ea-4f9e-11e6-9762-d97caf0fa7f8.gif)
